### PR TITLE
Save space in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,7 @@ RUN \
   a2enmod ssl && \
   a2ensite default-ssl && \
   a2enconf drupal && \
-  php5enmod drupal-recommended
-  
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+  php5enmod drupal-recommended && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 EXPOSE 80 443


### PR DESCRIPTION
If the `apt-get cleanup` is supposed to save space in the Docker image
it should not be done in a separate layer.
