### PR TITLE
Add Xdebug max nesting level to the configuration

### DIFF
--- a/files/etc/php5/mods-available/drupal-recommended.ini
+++ b/files/etc/php5/mods-available/drupal-recommended.ini
@@ -20,6 +20,8 @@ max_execution_time = 300
 ; Development-environment, we should have debugging available.
 xdebug.remote_enable = 1
 xdebug.remote_connect_back = 1
+# Drupal recommends that the max nesting level is 256.
+xdebug.max_nesting_level = 256
 
 ; enable opcache and ensure it has plenty of memory to work  with.
 opcache.enable=1


### PR DESCRIPTION
Drupal recommends that Xdebug's max nesting level is 256. - This will be default for Xdebug ^2.3 but 
the current version we download with `apt-get install php5-xdebug` is version 2.2.3 where the default value is 100.
