### PR TITLE
Add php56-mbstring extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN \
       php5.6-xml \
       php5.6-xdebug \
       php5.6-xhprof \
+      php5.6-mbstring \
       # For default snakeoil certificates which SSL is configuered to use
       # per default in Apache.
       ssl-cert \


### PR DESCRIPTION
The mbstring extension is on the [list of extensions we always need](https://reload.atlassian.net/wiki/display/RW/Standard+Drupal+7+serverkonfiguration) (i.e. ultimate_cron needs it).
