### PR TITLE
Make PHP extensions configurable on runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,13 @@ MAINTAINER Reload A/S <kontakt@reload.dk>
 COPY files/etc/ /etc/
 
 ENV PATH /root/.composer/vendor/bin:$PATH
+ENV PHP_VERSION 5.6
 
 RUN \
   apt-get update && \
   # Install packages needed to enable an extra repository.
   DEBIAN_FRONTEND=noninteractive apt-get -y install python-software-properties && \
-  # Add a repo that contains php 5.6
+  # Add a repo that contains php ${PHP_VERSION}
   LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php && \
   # Do the remaining installation of packages.
   apt-get update && \
@@ -19,18 +20,21 @@ RUN \
       apache2 \
       # Drush needs this to work
       mysql-client \
-      libapache2-mod-php5.6 \
-      php5.6-curl \
-      php5.6-gd \
-      php5.6-mysql \
-      php5.6-xml \
-      php5.6-xdebug \
-      php5.6-xhprof \
-      php5.6-mbstring \
-      php5.6-mcrypt \
-      php5.6-soap \
+      libapache2-mod-php${PHP_VERSION} \
+      # Default extensions.
+      php${PHP_VERSION}-curl \
+      php${PHP_VERSION}-gd \
+      php${PHP_VERSION}-mysql \
+      php${PHP_VERSION}-xml \
+      php${PHP_VERSION}-xdebug \
+      php${PHP_VERSION}-xhprof \
+      php${PHP_VERSION}-mbstring \
+      php${PHP_VERSION}-mcrypt \
+      php${PHP_VERSION}-soap \
       # Added for installing composer.
-      php5.6-zip \
+      php${PHP_VERSION}-zip \
+      # Other extensions
+      php${PHP_VERSION}-intl \
       # For default snakeoil certificates which SSL is configuered to use
       # per default in Apache.
       ssl-cert \
@@ -45,5 +49,7 @@ RUN \
   curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/local/bin --filename=composer && \
   composer global require drush/drush:8.* && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENV PHP_DEFAULT_EXTENSIONS calendar ctype curl dom exif fileinfo ftp gd gettext iconv json mcrypt mysql mysqli mysqlnd opcache pdo pdo_mysql phar posix readline shmop simplexml soap sockets sysvmsg sysvsem sysvshm tokenizer wddx xdebug xhprof xml xmlreader xmlwriter xsl mbstring zip
 
 EXPOSE 80 443

--- a/README.md
+++ b/README.md
@@ -2,3 +2,56 @@
 # Generic Drupal Apache container with SSL support.
 
 Memory limit has been raised to 256MiB, to give room for Features.
+
+# PHP extensions
+
+The following PHP extensions will be enabled by default:
+
+ * calendar
+ * ctype
+ * curl
+ * dom
+ * exif
+ * fileinfo
+ * ftp
+ * gd
+ * gettext
+ * iconv
+ * json
+ * mcrypt
+ * mysql
+ * mysqli
+ * mysqlnd
+ * opcache
+ * pdo
+ * pdo_mysql
+ * phar
+ * posix
+ * readline
+ * shmop
+ * simplexml
+ * soap
+ * sockets
+ * sysvmsg
+ * sysvsem
+ * sysvshm
+ * tokenizer
+ * wddx
+ * xdebug
+ * xhprof
+ * xml
+ * xmlreader
+ * xmlwriter
+ * xsl
+ * mbstring
+ * zip
+
+If you want extra extensions enabled add a space separated list of
+extensions to the environment variable `PHP_EXTRA_EXTENSIONS`.
+
+If you want fewer extensions enabled list _all_ the extensions you
+want enabled in the environment variable `PHP_DEFAULT_EXTENSIONS`.
+
+Currently the following extra extensions are supported:
+
+ * intl

--- a/files/etc/my_init.d/10_php_modules.sh
+++ b/files/etc/my_init.d/10_php_modules.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+PHP_EXTENSIONS="${PHP_DEFAULT_EXTENSIONS} ${PHP_EXTRA_EXTENSIONS}"
+PHP_AVAILABLE_EXTENSIONS=$(/usr/sbin/phpquery -q -v "${PHP_VERSION}" -s ALL -M)
+
+# Disable all modules first.
+for m in ${PHP_AVAILABLE_EXTENSIONS}; do
+    phpdismod -q -v "${PHP_VERSION}" -s ALL -m "${m}"
+done
+
+# Enable wanted modules now.
+for m in ${PHP_EXTENSIONS}; do
+    phpenmod -q -v "${PHP_VERSION}" -s ALL -m "${m}"
+done


### PR DESCRIPTION
The following PHP extensions will be enabled by default:
- calendar
- ctype
- curl
- dom
- exif
- fileinfo
- ftp
- gd
- gettext
- iconv
- json
- mcrypt
- mysql
- mysqli
- mysqlnd
- opcache
- pdo
- pdo_mysql
- phar
- posix
- readline
- shmop
- simplexml
- soap
- sockets
- sysvmsg
- sysvsem
- sysvshm
- tokenizer
- wddx
- xdebug
- xhprof
- xml
- xmlreader
- xmlwriter
- xsl
- mbstring
- zip

If you want extra extensions enabled add a space separated list of extensions to the environment variable `PHP_EXTRA_EXTENSIONS`.

If you want fewer extensions enabled list _all_ the extensions you want enabled in the environment variable `PHP_DEFAULT_EXTENSIONS`.

Currently the following extra extensions are supported:
- intl
