### PR TITLE
Make apache bind to the containers IP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,12 @@ RUN \
       ssl-cert \
       dnsutils \
       imagemagick \
-      unzip \
-  && \
+      unzip && \
+      apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY files/etc-post/ports.conf /etc/apache2/
+
+RUN \
   a2enmod rewrite && \
   a2enmod ssl && \
   a2ensite default-ssl && \
@@ -55,7 +59,7 @@ RUN \
   # Drush 8 is the current stable that supports Drupal version 6, 7 and 8.
   curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/local/bin --filename=composer && \
   composer global require drush/drush:8.* && \
-  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+  rm -rf /tmp/* /var/tmp/*
 
 ENV PHP_DEFAULT_EXTENSIONS calendar ctype curl dom exif fileinfo ftp gd gettext iconv json mcrypt mysql mysqli mysqlnd opcache pdo pdo_mysql phar posix readline shmop simplexml soap sockets sysvmsg sysvsem sysvshm tokenizer wddx xhprof xml xmlreader xmlwriter xsl mbstring zip
 

--- a/files/etc-post/ports.conf
+++ b/files/etc-post/ports.conf
@@ -1,0 +1,16 @@
+# If you just change the port or add more ports here, you will likely also
+# have to change the VirtualHost statement in
+# /etc/apache2/sites-enabled/000-default.conf
+
+Listen 127.0.0.1:80
+Listen [::1]:80
+
+<IfModule ssl_module>
+	Listen 127.0.0.1:443
+	Listen [::1]:443
+</IfModule>
+
+<IfModule mod_gnutls.c>
+	Listen 127.0.0.1:443
+	Listen [::1]:443
+</IfModule>

--- a/files/etc-post/ports.conf
+++ b/files/etc-post/ports.conf
@@ -2,15 +2,21 @@
 # have to change the VirtualHost statement in
 # /etc/apache2/sites-enabled/000-default.conf
 
-Listen 127.0.0.1:80
-Listen [::1]:80
+# The docker-host will connect to us via $HOSTNAME
+Listen ${HOSTNAME}:80
 
+# For eg. quick local testing, we'll also bind to localhost
+Listen 127.0.0.1:80
+
+# SSL configuration.
 <IfModule ssl_module>
+	Listen ${HOSTNAME}:443
 	Listen 127.0.0.1:443
 	Listen [::1]:443
 </IfModule>
 
 <IfModule mod_gnutls.c>
+	Listen ${HOSTNAME}:443
 	Listen 127.0.0.1:443
 	Listen [::1]:443
 </IfModule>


### PR DESCRIPTION
Pr default the apache will bind to all ip's, making it impossible for something local to bind to port 80.
This PR makes apache bind specifically to 127.0.0.1 and the containers public ip - leaving the remaining 127.0.0.0/8 for local tinkering - eg a ssh-tunnel.
